### PR TITLE
Reserve space for Result when it's not displayed.

### DIFF
--- a/client/src/__snapshots__/App.test.js.snap
+++ b/client/src/__snapshots__/App.test.js.snap
@@ -4,6 +4,25 @@ exports[`<App /> renders default state 1`] = `
 <div
   className="App"
 >
+  <div>
+    <p
+      className="result-first-line hidden"
+    >
+       
+      1
+       
+      Needs to be calculated!
+       equals 
+    </p>
+    <p
+      className="result-second-line hidden"
+    >
+       
+       
+      Needs to be calculated!
+       
+    </p>
+  </div>
   <div
     className="rowC"
   >

--- a/client/src/components/Dropdown.js
+++ b/client/src/components/Dropdown.js
@@ -11,7 +11,7 @@ export class Dropdown extends React.Component {
       <select
         onChange={event => this.props.onChange(this.props.stateKey, event.target.value)}
       >
-        <option>Choose currency...</option>
+        <option value=''>Choose currency...</option>
         {(this.props.currencies).map((x, i) => <option key={i}>{x}</option>)}
       </select>;
 

--- a/client/src/components/FullResult.js
+++ b/client/src/components/FullResult.js
@@ -2,18 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FullResult = ({currA, currB, names, currAval, result}) => {
-  if (currA && currB && currAval && result) {
-    const nameA = currAval > 1 ? names[currA].name_plural : names[currA].name;
-    const nameB = result > 1 ? names[currB].name_plural : names[currB].name;
-    return (
-      <div>
-        <p className='result-first-line'> {currAval} {nameA} equals </p>
-        <p className='result-second-line'> {result} {nameB} </p>
-      </div>
-    );
-  } else {
-    return null;
+  let nameA = 'Needs to be calculated!';
+  let nameB = 'Needs to be calculated!';
+  let isDataSet = currA && currB && currAval && result;
+  if (isDataSet) {
+    nameA = currAval > 1 ? names[currA].name_plural : names[currA].name;
+    nameB = result > 1 ? names[currB].name_plural : names[currB].name;
   }
+  return (
+    <div>
+      <p className={isDataSet ? 'result-first-line' : 'result-first-line hidden'}> {currAval} {nameA} equals </p>
+      <p className={isDataSet ? 'result-second-line' : 'result-second-line hidden'}> {result} {nameB} </p>
+    </div>
+  );
 };
 
 export default FullResult;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -49,3 +49,7 @@ input, select {
   font-size: 25px;
   color: black;
 }
+
+.hidden {
+  visibility: hidden;
+}


### PR DESCRIPTION
Connects to #2
Space at the top of the page is now reserved for a result even if it is not displayed